### PR TITLE
return args passed to promise callback so that promise works properly even when a callback is provided

### DIFF
--- a/lib/wrapPromise.js
+++ b/lib/wrapPromise.js
@@ -24,6 +24,7 @@ var wrapPromise = function(promise, cb, options) {
           cb(null, args);
         });
       }
+      return args
     }).catch(function(err) {
       setImmediate(function() {
         cb(err);


### PR DESCRIPTION
Plaid has two ways of doing API calls. Most of the functions provided by PlaidClient use callbacks that get passed into the request promise by wrapPromise. However, some of the functions aggregate multiple paginated results into a single response object and in these cases, the value is returned directly via the promise.

This change makes it so that the value is returned directly via the promise even when a callback is provided.

I'm making this change to make progress on https://github.com/hellodigit/digit/issues/18774. A PR describe what's going to happen on the digit side of things can be found here: https://github.com/hellodigit/digit/pull/19312. The general idea is that I'm overriding the `_authenticatedRequest` in order to add my own middleware, and Plaid doesn't return the response object properly without this change.